### PR TITLE
Ecs: Fix invalid read in IteratorWrapper::increase()

### DIFF
--- a/src/Ecs.hpp
+++ b/src/Ecs.hpp
@@ -216,7 +216,7 @@ bool Ecs::IteratorWrapper<T_Component>::increase(const EntityId& eId)
     while (it != end && it->eId < eId)
         ++it;
 
-    return (it->eId > eId || it == end) ? false : true;
+    return (it == end || it->eId > eId) ? false : true;
 }
 
 template<typename... T_Components>


### PR DESCRIPTION
The boundary check was done after the access because the operands of an
|| operator are short-cirucit evaluated from left to right.